### PR TITLE
Import @nextcloud/vue components directly to shrink asset size

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script>
-import { NcContent } from '@nextcloud/vue'
+import NcContent from '@nextcloud/vue/dist/Components/NcContent.js'
 import PandocView from './views/PandocView.vue'
 
 export default {

--- a/src/components/FileContent.vue
+++ b/src/components/FileContent.vue
@@ -44,7 +44,8 @@
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
-import { NcEmptyContent, NcProgressBar } from '@nextcloud/vue'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
+import NcProgressBar from '@nextcloud/vue/dist/Components/NcProgressBar.js'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon.vue'
 import DownloadIcon from 'vue-material-design-icons/Download.vue'
 

--- a/src/views/PandocView.vue
+++ b/src/views/PandocView.vue
@@ -13,7 +13,8 @@
 </template>
 
 <script>
-import { NcAppContent, NcEmptyContent } from '@nextcloud/vue'
+import NcAppContent from '@nextcloud/vue/dist/Components/NcAppContent.js'
+import NcEmptyContent from '@nextcloud/vue/dist/Components/NcEmptyContent.js'
 import AlertOctagonIcon from 'vue-material-design-icons/AlertOctagon.vue'
 import FileContent from '../components/FileContent.vue'
 


### PR DESCRIPTION
Since we only use very few components it currently saves us more than 2MB to import the components directly.

Signed-off-by: Jonas <jonas@freesources.org>