### PR TITLE
Make dependabot ignore updates to vue 3 and vuex 4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,11 @@ updates:
     day: saturday
     time: "03:00"
     timezone: Europe/Paris
+  ignore:
+  - dependency-name: "vue"
+    versions: ["^3"]
+  - dependency-name: "vuex"
+    versions: ["^4"]
   open-pull-requests-limit: 10
   labels:
   - 3. to review


### PR DESCRIPTION
Signed-off-by: Jonas <jonas@freesources.org>